### PR TITLE
Fixed bad transparency mask error

### DIFF
--- a/qrvanity.py
+++ b/qrvanity.py
@@ -10,7 +10,7 @@ import zbarlight
 import sys
 
 with open(sys.argv[1], 'rb') as input_file:
-    input_image = Image.open(input_file)
+    input_image = Image.open(input_file).convert("RGBA")
     try:
         input_image.load()
     except (OSError, IOError) as e:


### PR DESCRIPTION
Attempting to use a png with a transparent background led to ValueError: bad transparency mask on line 42. Converting the image to RGBA color space resolved the error.